### PR TITLE
Automatic Package Versioning for digital-growth-chart-server

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,3 +29,14 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*
+
+    - name: Delay 15min to wait for publish to pypi
+      run: |
+        sleep 15m
+
+    - name: Initiate repository event in rcpch_server
+      run: |
+        curl -X POST https://api.github.com/repos/rcpch/digital-growth-charts-server/dispatches \
+        -H 'Accept: application/vnd.github.v3+json' \
+        -u ${{ secrets.ACCESS_TOKEN }} \
+        -d '{"event_type":"publish_to_pypi"}'


### PR DESCRIPTION
**This is part of Automatic Package Versioning issue in digital-growth-chart-server**
wait 15min then send respository_dispatch event to rcpchgrowth-server to trigger live-deploy-to-azure github action

- [ ] setup ACCESS_TOKEN in secrets with token that has repo access