### PR TITLE
deprecate pkg_utils

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.2
+current_version = 4.0.0
 tag = False
 commit = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,5 +4,5 @@ tag = False
 commit = True
 
 [bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
+search = version="{current_version}"
+replace = version="{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.1
+current_version = 3.2.2
 tag = False
 commit = True
 

--- a/rcpchgrowth/trisomy_21.py
+++ b/rcpchgrowth/trisomy_21.py
@@ -1,5 +1,6 @@
 import json
-import pkg_resources
+from importlib import resources
+from pathlib import Path
 from .constants import *
 # from .global_functions import z_score, cubic_interpolation, linear_interpolation, centile, measurement_for_z, nearest_lowest_index, fetch_lms
 # import timeit #see below, comment back in if timing functions in this module
@@ -18,10 +19,13 @@ lms: L, M or S
 reference: reference data
 """
 
-#load the reference data
+# load the reference data
+data_directory = resources.files("rcpchgrowth.data_tables")
 
-TRISOMY_21_DATA = pkg_resources.resource_filename(__name__, "/data_tables/trisomy_21.json")
-with open(TRISOMY_21_DATA) as json_file:
+
+
+data_path = Path(data_directory, "trisomy_21.json")
+with open(data_path) as json_file:
             TRISOMY_21_DATA = json.load(json_file)
             json_file.close()
 

--- a/rcpchgrowth/turner.py
+++ b/rcpchgrowth/turner.py
@@ -1,5 +1,6 @@
 import json
-import pkg_resources
+from importlib import resources
+from pathlib import Path
 from .constants import *
 # import timeit #see below, comment back in if timing functions in this module
 
@@ -17,10 +18,11 @@ lms: L, M or S
 reference: reference data
 """
 
-#load the reference data
+# load the reference data
+data_directory = resources.files("rcpchgrowth.data_tables")
 
-TURNER_DATA = pkg_resources.resource_filename(__name__, "/data_tables/turner.json")
-with open(TURNER_DATA) as json_file:
+data_path = Path(data_directory, "turner.json")
+with open(data_path) as json_file:
             TURNER_DATA = json.load(json_file)
             json_file.close()
 

--- a/rcpchgrowth/uk_who.py
+++ b/rcpchgrowth/uk_who.py
@@ -4,7 +4,8 @@ Handles UK-WHO-specific reference data selection
 
 # standard imports
 import json
-import pkg_resources
+from importlib import resources
+from pathlib import Path
 
 # rcpch imports
 from .constants import *
@@ -24,34 +25,35 @@ reference: reference data
 """
 
 # load the reference data
+data_directory = resources.files("rcpchgrowth.data_tables")
 
-UK90_PRETERM_DATA = pkg_resources.resource_filename(
-    __name__, "/data_tables/uk90_preterm.json")  # 23 - 42 weeks gestation
-with open(UK90_PRETERM_DATA) as json_file:
+data_path = Path(
+    data_directory, "uk90_preterm.json")  # 23 - 42 weeks gestation
+with open(data_path) as json_file:
     UK90_PRETERM_DATA = json.load(json_file)
     json_file.close()
 
-UK90_TERM_DATA = pkg_resources.resource_filename(
-    __name__, "/data_tables/uk90_term.json")  # 37-42 weeks gestation
-with open(UK90_TERM_DATA) as json_file:
+data_path = Path(
+    data_directory, "uk90_term.json")  # 37-42 weeks gestation
+with open(data_path) as json_file:
     UK90_TERM_DATA = json.load(json_file)
     json_file.close()
 
-WHO_INFANTS_DATA = pkg_resources.resource_filename(
-    __name__, "/data_tables/who_infants.json")  # 2 weeks to 2 years
-with open(WHO_INFANTS_DATA) as json_file:
+data_path = Path(
+    data_directory, "who_infants.json")  # 2 weeks to 2 years
+with open(data_path) as json_file:
     WHO_INFANTS_DATA = json.load(json_file)
     json_file.close()
 
-WHO_CHILD_DATA = pkg_resources.resource_filename(
-    __name__, "/data_tables/who_children.json")  # 2 years to 4 years
-with open(WHO_CHILD_DATA) as json_file:
+data_path = Path(
+    data_directory, "who_children.json")  # 2 years to 4 years
+with open(data_path) as json_file:
     WHO_CHILD_DATA = json.load(json_file)
     json_file.close()
 
-UK90_CHILD_DATA = pkg_resources.resource_filename(
-    __name__, "/data_tables/uk90_child.json")  # 4 years to 20 years
-with open(UK90_CHILD_DATA) as json_file:
+data_path = Path(
+    data_directory, "uk90_child.json")  # 4 years to 20 years
+with open(data_path) as json_file:
     UK90_CHILD_DATA = json.load(json_file)
     json_file.close()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,6 @@
-attrs
 bump2version
-iniconfig
-packaging
-pluggy
-py
-pyparsing
 pytest
 python-dateutil
 scipy
-toml
 matplotlib
 setuptools

--- a/setup.py
+++ b/setup.py
@@ -1,46 +1,34 @@
-from setuptools import _install_setup_requires, setup, find_packages
+from setuptools import setup, find_packages
 from os import path
 
 here = path.abspath(path.dirname(__file__))
 
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    name='rcpchgrowth',
-    version='3.2.2',
-    description='SDS and Centile calculations for UK Growth Data',
-    long_description="https://github.com/rcpch/digital-growth-charts/blob/master/README.md",
-    url='https://github.com/rcpch/digital-growth-charts/blob/master/README.md',
-    author='@eatyourpeas, @marcusbaw @statist7 RCPCH',
-
-    author_email='eatyourpeasapps@gmail.com',
+    name="rcpchgrowth",
+    version="3.2.2",
+    description="SDS and Centile calculations for UK Growth Data",
+    long_description=long_description,
+    url="https://github.com/rcpch/digital-growth-charts/blob/master/README.md",
+    author="@eatyourpeas, @marcusbaw, @statist7, RCPCH Incubator",
+    author_email="incubator@rcpch.ac.uk",
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
-        'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3 :: Only',
-        'Topic :: Scientific/Engineering :: Medical Science Apps.'
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3 :: Only",
+        "Topic :: Scientific/Engineering :: Medical Science Apps.",
     ],
-    keywords='growth charts anthropometry SDS Centile',  
-    
-    packages=find_packages(),  
-    python_requires='>=3.8, <=3.12',
-    install_requires=[
-        'python-dateutil',
-        "scipy",
-        'six',
-        'pytest',
-        'click'
-    ],  
-    extras_require={  
-        'dev': ['check-manifest'],
-        'test': ['coverage'],
-    },
+    keywords="growth charts, anthropometry, SDS, centile, UK-WHO, UK90, Trisomy 21, Turner",
+    packages=find_packages(),
+    python_requires=">3.8",
+    install_requires=["python-dateutil", "scipy"],
     include_package_data=True,
-    project_urls={  
-        'Bug Reports': 'https://github.com/rcpch/digital-growth-charts/issues',
-        'API management': 'https://dev.rcpch.ac.uk',
-        'Source': 'https://github.com/rcpch/digital-growth-charts',
+    project_urls={
+        "Bug Reports": "https://github.com/rcpch/rcpchgrowth-python/issues",
+        "API management": "https://dev.rcpch.ac.uk",
+        "Source": "https://github.com/rcpch/rcpchgrowth-python",
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="rcpchgrowth",
-    version="3.2.2",
+    version="4.0.0",
     description="SDS and Centile calculations for UK Growth Data",
     long_description=long_description,
     url="https://github.com/rcpch/digital-growth-charts/blob/master/README.md",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='rcpchgrowth',
-    version='3.2.1',
+    version='3.2.2',
     description='SDS and Centile calculations for UK Growth Data',
     long_description="https://github.com/rcpch/digital-growth-charts/blob/master/README.md",
     url='https://github.com/rcpch/digital-growth-charts/blob/master/README.md',


### PR DESCRIPTION
### Overview
Data files are imported as json files within the package. Previously this has been done with pkg_resources but this is now deprecated and nolonger supported in python 3.12, in favour of `importlib`

### Code changes
All references to pkg_resources have been removed
`importlib` is imported in the `trisomy_21`, `turner` and `uk_who` files and loaded in from the `data_tables` module.
Also bumps the package version to 3.2.2

### Documentation changes (done or required as a result of this PR)
This should not have any implications for documentation

### Related Issues
closes #27
