### PR TITLE
Don't-correct-cdc-term

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.2.6
+current_version = 4.2.7
 tag = False
 commit = True
 

--- a/rcpchgrowth/age_advice_strings.py
+++ b/rcpchgrowth/age_advice_strings.py
@@ -22,9 +22,9 @@ def comment_prematurity_correction(
                     clinician_corrected_decimal_age_comment = f"Born preterm at {gestation_weeks}+{gestation_days} weeks gestation. No correction is made for this beyond 2 years of age."
                 else:
                     lay_chronological_decimal_age_comment = f"Your child was born at {gestation_weeks}+{gestation_days} weeks gestation. This is considered term and no correction for gestation has been made."
-                    clinician_chronological_decimal_age_comment = f"Born at term at {gestation_weeks}+{gestation_days} weeks gestation. This is considered term and no correction for gestation has been made."
+                    clinician_chronological_decimal_age_comment = f"Born at term at {gestation_weeks}+{gestation_days} weeks gestation. No correction for gestation has been made."
                     lay_corrected_decimal_age_comment = f"Your child was born at {gestation_weeks}+{gestation_days} weeks gestation. This is considered term and no correction for gestation has been made."
-                    clinician_corrected_decimal_age_comment = f"Born at term at {gestation_weeks}+{gestation_days} weeks gestation. This is considered term and no correction for gestation has been made."
+                    clinician_corrected_decimal_age_comment = f"Born at term at {gestation_weeks}+{gestation_days} weeks gestation. No correction for gestation has been made."
     elif chronological_decimal_age > corrected_decimal_age or chronological_decimal_age < corrected_decimal_age:
         ## adjustment for gestational age has been made - even if >=37 weeks
         lay_corrected_decimal_age_comment = f"Because your child was born at {gestation_weeks}+{gestation_days} weeks gestation an adjustment has been made to take this into account."

--- a/rcpchgrowth/age_advice_strings.py
+++ b/rcpchgrowth/age_advice_strings.py
@@ -8,11 +8,23 @@ def comment_prematurity_correction(
     """
 
     if chronological_decimal_age == corrected_decimal_age:
-        # no adjustment has been made so the child was born at 40 weeks
+        # no adjustment has been made so the child was born at 40 weeks or this child is being plotted on the CDC reference, where no adjustment is made for 37-42 weeks or beyond the age of 2 years
             lay_corrected_decimal_age_comment = "Your child was born on their due date."
             clinician_corrected_decimal_age_comment = "Born at term. No correction has been made for gestation."
             lay_chronological_decimal_age_comment = "Your child was born on their due date."
             clinician_chronological_decimal_age_comment = "Born Term. No correction has been made for gestation."
+            # These fields should only apply to CDC reference, since UK-WHO corrects for all gestations (and therefore corrected_decimal_age will never be equal to chronological_decimal_age if gestation_weeks is not 40)
+            if gestation_weeks < 42:
+                if gestation_weeks < 37:
+                    lay_chronological_decimal_age_comment = f"Your child was born at {gestation_weeks}+{gestation_days} weeks gestation. No correction is made for this beyond 2 years of age."
+                    clinician_chronological_decimal_age_comment =f"Born preterm at {gestation_weeks}+{gestation_days} weeks gestation. No correction is made for this beyond 2 years of age."
+                    lay_corrected_decimal_age_comment = f"Your child was born at {gestation_weeks}+{gestation_days} weeks gestation. No correction is made for this beyond 2 years of age."
+                    clinician_corrected_decimal_age_comment = f"Born preterm at {gestation_weeks}+{gestation_days} weeks gestation. No correction is made for this beyond 2 years of age."
+                else:
+                    lay_chronological_decimal_age_comment = f"Your child was born at {gestation_weeks}+{gestation_days} weeks gestation. This is considered term and no correction for gestation has been made."
+                    clinician_chronological_decimal_age_comment = f"Born at term at {gestation_weeks}+{gestation_days} weeks gestation. This is considered term and no correction for gestation has been made."
+                    lay_corrected_decimal_age_comment = f"Your child was born at {gestation_weeks}+{gestation_days} weeks gestation. This is considered term and no correction for gestation has been made."
+                    clinician_corrected_decimal_age_comment = f"Born at term at {gestation_weeks}+{gestation_days} weeks gestation. This is considered term and no correction for gestation has been made."
     elif chronological_decimal_age > corrected_decimal_age or chronological_decimal_age < corrected_decimal_age:
         ## adjustment for gestational age has been made - even if >=37 weeks
         lay_corrected_decimal_age_comment = f"Because your child was born at {gestation_weeks}+{gestation_days} weeks gestation an adjustment has been made to take this into account."

--- a/rcpchgrowth/measurement.py
+++ b/rcpchgrowth/measurement.py
@@ -395,6 +395,11 @@ class Measurement:
             gestation_weeks = 40
         # calculate ages from dates and gestational ages at birth
 
+        # if reference is CDC, we must treat >37 week infants as term.
+        if self.reference == CDC and gestation_weeks >= 37:
+            gestation_weeks = 40
+            gestation_days = 0
+
         try:
             self.corrected_decimal_age = corrected_decimal_age(
                 birth_date=birth_date,
@@ -412,6 +417,10 @@ class Measurement:
         except Exception as err:
             self.chronological_decimal_age = None
             chronological_decimal_age_error = f"{err}"
+        
+        # if the reference is CDC, we also stop correcting for prematurity at 2 years of age
+        if self.reference == CDC and self.corrected_decimal_age >= 2:
+            self.corrected_decimal_age = self.chronological_decimal_age
 
         if self.corrected_decimal_age is None:
             self._age_comments = None

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="rcpchgrowth",
-    version="4.2.6",
+    version="4.2.7",
     description="SDS and Centile calculations for UK Growth Data",
     long_description=long_description,
     url="https://github.com/rcpch/digital-growth-charts/blob/master/README.md",


### PR DESCRIPTION
### Overview

Supplementary change following on from previous patch where preterm  requests for absent data have meaningful error messages returned.

In CDC age correction does not occur for any babies that are born gestation 37-42 weeks, or any preterm babies >2y of age.

A conditional has been added to check for gestation in the Measurement class where reference requested is CDC. In these circumstances, chronological and corrected ages are reset to be equal, and the discrepancy between this and supplied gestation is used in the `age_advice_strings` function to give the correct feed back to users on when age correction has happened