### PR TITLE
Converted "return" to "raise" for invalid values in cdc.py & uk_who.py

### DIFF
--- a/rcpchgrowth/cdc.py
+++ b/rcpchgrowth/cdc.py
@@ -97,7 +97,7 @@ def cdc_reference(age: float, measurement_method, default_youngest_reference: bo
         return CDC_CHILD_DATA 
 
     else:
-        return ValueError("There is no CDC reference data above the age of 20 years.")
+        raise ValueError("There is no CDC reference data above the age of 20 years.")
 
 
 def cdc_lms_array_for_measurement_and_sex(

--- a/rcpchgrowth/uk_who.py
+++ b/rcpchgrowth/uk_who.py
@@ -117,7 +117,7 @@ def uk_who_reference(
     # These conditionals are to select the correct reference
     if age < UK90_REFERENCE_LOWER_THRESHOLD:
         # Below the range for which we have reference data, we can't provide a calculation.
-        return ValueError("There is no UK90 reference data below 23 weeks gestation")
+        raise ValueError("There is no UK90 reference data below 23 weeks gestation")
     elif age < UK_WHO_INFANT_LOWER_THRESHOLD:
         # Below 42 weeks, the UK90 preterm data is always used
         return UK90_PRETERM_DATA
@@ -147,7 +147,7 @@ def uk_who_reference(
         return UK90_CHILD_DATA
 
     else:
-        return ValueError("There is no UK90 reference data above the age of 20 years.")
+        raise ValueError("There is no UK90 reference data above the age of 20 years.")
 
 
 def uk_who_lms_array_for_measurement_and_sex(
@@ -165,7 +165,7 @@ def uk_who_lms_array_for_measurement_and_sex(
             default_youngest_reference=default_youngest_reference
         )
     except:  #  there is no reference for the age supplied
-        return LookupError("There is no UK-WHO reference for the age supplied.")
+        raise LookupError("There is no UK-WHO reference for the age supplied.")
 
     # Check that the measurement requested has reference data at that age
 


### PR DESCRIPTION
### Overview

Changing the return Error to Raise Error as discussed in https://github.com/rcpch/rcpchgrowth-python/issues/51

### Code changes

As above

### Related Issues

Tests have all passed
There's no testing of error pathways - not sure if you'd like me to look into this as well?

### Mentions

@eatyourpeas 
