### PR TITLE
who-mid-parental-height

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.3.0
+current_version = 4.3.1
 tag = False
 commit = True
 

--- a/rcpchgrowth/chart_functions.py
+++ b/rcpchgrowth/chart_functions.py
@@ -351,6 +351,10 @@ def create_uk_who_chart(
                 sex=sex)
         except:
             lms_array_for_measurement = []
+        
+        # truncate the who_child data to stop at 4y
+        if len(lms_array_for_measurement) > 0:
+            lms_array_for_measurement = [obj for obj in lms_array_for_measurement if obj["decimal_age"] <= 4.0]
 
         for centile_index, centile_sds in enumerate(centile_sds_collection):
             # we must create a z for each requested centile

--- a/rcpchgrowth/mid_parental_height.py
+++ b/rcpchgrowth/mid_parental_height.py
@@ -1,4 +1,4 @@
-from .constants import HEIGHT, MALE, FEMALE, UK_WHO
+from .constants import HEIGHT, MALE, FEMALE, UK_WHO, WHO
 from .global_functions import sds_for_measurement
 """
 Functions to calculate mid-parental height
@@ -23,8 +23,12 @@ def mid_parental_height_z(maternal_height, paternal_height, reference=UK_WHO):
     """
     
     # convert parental heights to z-scores
-    maternal_height_z = sds_for_measurement(reference=reference, age=20.0, measurement_method=HEIGHT, observation_value=maternal_height, sex=FEMALE)
-    paternal_height_z = sds_for_measurement(reference=reference, age=20.0, measurement_method=HEIGHT, observation_value=paternal_height, sex=MALE)
+    adult_age = 20.0
+    if reference == WHO:
+        adult_age = 19.0
+    
+    maternal_height_z = sds_for_measurement(reference=reference, age=adult_age, measurement_method=HEIGHT, observation_value=maternal_height, sex=FEMALE)
+    paternal_height_z = sds_for_measurement(reference=reference, age=adult_age, measurement_method=HEIGHT, observation_value=paternal_height, sex=MALE)
 
     # take the means of the z-scores and apply the regression coefficient of 0.5 - simplifed: (MatHtz +PatHtz)/4
     mid_parental_height_z_score = (maternal_height_z + paternal_height_z) / 4.0

--- a/rcpchgrowth/who.py
+++ b/rcpchgrowth/who.py
@@ -170,7 +170,7 @@ def select_reference_data_for_who_chart(
     elif who_reference_name == WHO_2006_CHILD:
         try:
             who_2006_children_reference = who_lms_array_for_measurement_and_sex(
-                age=1.0,
+                age=3.0,
                 measurement_method=measurement_method,
                 sex=sex,
                 default_youngest_reference=default_youngest_reference # should never need younger reference in this calculation


### PR DESCRIPTION
### Overview

Fixes mid-parental height calculation for WHO reference, where reference data is used for adults at 19y for SDS calculation (as opposed to CDC and UK90 which use 20y)

Also fixes two errors:
- that uk-who `create_chart` included who reference data to 5y. This is now filter out over 4y
- who reference `create_chart` was incorrectly adding infant data to the child element in the response. 

### Related Issues

fixes #55 #56

