### PR TITLE
returns who data not cdc data for under 2s in cdc weight/height/bmi. ofc remains cdc

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.3.4
+current_version = 4.3.5
 tag = False
 commit = True
 

--- a/rcpchgrowth/cdc.py
+++ b/rcpchgrowth/cdc.py
@@ -44,6 +44,12 @@ with open(data_path) as json_file:
     json_file.close()
 # public functions
 
+data_path = Path(
+    data_directory, "who_infants.json")  # 2 weeks to 2 years
+with open(data_path) as json_file:
+    WHO_INFANTS_DATA = json.load(json_file)
+    json_file.close()
+
 
 def reference_data_absent(age: float, measurement_method: str, sex: str):
     """
@@ -88,9 +94,13 @@ def cdc_reference(age: float, measurement_method, default_youngest_reference: bo
         # Below 40 weeks, Fenton data is always used
         return FENTON_DATA
     
-    elif age < 2 or (age == 2 and default_youngest_reference) or (measurement_method == HEAD_CIRCUMFERENCE and age <= 3):
-        # Below 2 years, CDC interpretation of WHO is used
+    if measurement_method == HEAD_CIRCUMFERENCE and age <= 3:
+        # CDC data is used for head circumference up to 3 years
         return CDC_INFANT_DATA
+
+    elif age < 2 or (age == 2 and default_youngest_reference):
+        # Below 2 years, CDC interpretation of WHO is used
+        return WHO_INFANTS_DATA
 
     elif age <= CDC_UPPER_THRESHOLD:
         # CDC data is used for all children 2-20 years

--- a/rcpchgrowth/measurement.py
+++ b/rcpchgrowth/measurement.py
@@ -415,7 +415,7 @@ class Measurement:
             chronological_decimal_age_error = f"{err}"
         
         # if reference is CDC or WHO, we must treat >37 week infants as term and we also stop correcting for prematurity at 2 years of age
-        if self.reference == CDC or self.reference == WHO:
+        if self.reference == CDC or self.reference == WHO and self.corrected_decimal_age  is not None:
             if (self.corrected_decimal_age >= 2 and gestation_weeks < 37) or (gestation_weeks >= 37 and gestation_weeks <= 42):
                 self.corrected_decimal_age = self.chronological_decimal_age
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="rcpchgrowth",
-    version="4.3.4",
+    version="4.3.5",
     description="SDS and Centile calculations for UK Growth Data",
     long_description=long_description,
     url="https://github.com/rcpch/digital-growth-charts/blob/master/README.md",


### PR DESCRIPTION
### Overview

An astute observation by Dr Coleman was that the centile values returned from the CDC endpoint were not WHO values. The datasets have been changed here to return WHO infant data for the under 2s except in head circumference where CDC data is returned

closes #63