### PR TITLE
More-context-to-measurement-out-of-bounds

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.3.6
+current_version = 4.3.7
 tag = False
 commit = True
 

--- a/rcpchgrowth/measurement.py
+++ b/rcpchgrowth/measurement.py
@@ -644,10 +644,10 @@ class Measurement:
                     'Height/length must be passed in cm, not metres')
             elif observation_value_z_score < MINIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS:
                 raise ValueError(
-                    f'The height/length of {observation_value} cm is below -8 SD and considered to be an error.')
+                    f'The height/length of {observation_value} cm in a child of {round(corrected_decimal_age, 1)} years is below -8 SD and considered to be an error.')
             elif observation_value_z_score > MAXIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS:
                 raise ValueError(
-                    f'The height/length of {observation_value} cm is above +8 SD and considered to be an error.')
+                    f'The height/length of {observation_value} cm in a child of {round(corrected_decimal_age, 1)} years is above +8 SD and considered to be an error.')
             else:
                 is_valid = True
 
@@ -657,11 +657,11 @@ class Measurement:
                     'Missing observation_value for weight. Please pass a weight in kilograms.')
             elif observation_value_z_score < MINIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS:
                 raise ValueError(
-                    f'The weight of {observation_value} kg is below -8 SD and considered to be an error.')
+                    f'The weight of {observation_value} kg is below -8 SD in a child of {round(corrected_decimal_age, 1)} years and considered to be an error.')
             elif observation_value_z_score > MAXIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS:
                 # it is likely the weight is passed in grams, not kg.
                 raise ValueError(
-                    f'The weight of {observation_value} kg is above +8 SD and considered to be an error. Note that the weight should be supplied in kilograms.')
+                    f'The weight of {observation_value} kg is above +8 SD in a child of {round(corrected_decimal_age, 1)} years and considered to be an error. Note that the weight should be supplied in kilograms.')
             else:
                 is_valid = True
 
@@ -671,10 +671,10 @@ class Measurement:
                     'Missing observation_value for head circumference. Please pass a head circumference in centimetres.')
             elif observation_value_z_score < MINIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS:
                 raise ValueError(
-                    f'The head circumference of {observation_value} cm is below -8 SD and considered to be an error.')
+                    f'The head circumference of {observation_value} cm in a child of {round(corrected_decimal_age, 1)} years is below -8 SD and considered to be an error.')
             elif observation_value_z_score > MAXIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS:
                 raise ValueError(
-                    f'The head circumference of {observation_value} cm is above +8 SD and considered to be an error.')
+                    f'The head circumference of {observation_value} cm in a child of {round(corrected_decimal_age, 1)} years is above +8 SD and considered to be an error.')
             else:
                 is_valid = True
 

--- a/rcpchgrowth/tests/test_measurement_class.py
+++ b/rcpchgrowth/tests/test_measurement_class.py
@@ -57,6 +57,7 @@ def test_measurement_class_ukwho_data(line):
         assert measurement_object.measurement[
             "measurement_calculated_values"]['corrected_sds'] is None
     else:
+        age = measurement_object.measurement['measurement_dates']['corrected_decimal_age']
         # Check if the value is a float and has no fractional part
         assert measurement_object.measurement[
             "measurement_calculated_values"]['corrected_sds'] == pytest.approx(
@@ -74,7 +75,7 @@ def test_measurement_class_ukwho_data(line):
                 measurement_method = "height/length"
             elif measurement_method == "weight":
                 units="kg"
-            assert measurement_object.measurement["child_observation_value"]["observation_value_error"] == f'The {measurement_method} of {observation_value} {units} is above +8 SD and considered to be an error.'
+            assert measurement_object.measurement["child_observation_value"]["observation_value_error"] == f'The {measurement_method} of {observation_value} {units} in a child of {round(age, 1)} years is above +8 SD and considered to be an error.'
         elif line["corrected_sds"] > 4 and line["corrected_sds"] <= 15 and line["measurement_method"] == BMI:
             assert measurement_object.measurement[
                 "measurement_calculated_values"]['corrected_centile_band'] == f"This {line['measurement_method']} measurement is well outside the normal range. Please check its accuracy."

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="rcpchgrowth",
-    version="4.3.6",
+    version="4.3.7",
     description="SDS and Centile calculations for UK Growth Data",
     long_description=long_description,
     url="https://github.com/rcpch/digital-growth-charts/blob/master/README.md",


### PR DESCRIPTION
### Overview

Consumers of the digital growth charts API are finding that +/- 8 SDS errors are not intuitive and requested that the age of the child be included in the error response.

changes in this PR are to include the age of the child in the error message