### PR TITLE
Fictional-child-track-corrected-age

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.3.7
+current_version = 4.3.8
 tag = False
 commit = True
 

--- a/rcpchgrowth/fictional_child.py
+++ b/rcpchgrowth/fictional_child.py
@@ -50,8 +50,14 @@ def generate_fictional_child_data(
   birth_date = date(1759, 4, 11)  # YYYY m d
   observation_date = birth_date + timedelta(days=start_chronological_age*365.25)
   
+  # adjust the age for gestation
+  correction = 0.0
+  if gestation_weeks < 40:
+    correction = (((gestation_weeks * 7 + gestation_days)-40*7) / 365.25)  # adjust age for gestation
+
   # set the counters
-  cycle_age = start_chronological_age
+  cycle_age = start_chronological_age + correction  # adjust the age for gestation
+  end_age += correction  # adjust the end age for gestation
   cycle_sds = start_sds 
 
   interval_in_years = end_age-start_chronological_age
@@ -76,7 +82,7 @@ def generate_fictional_child_data(
     drift_amount = drift_range / cycle_number
 
   measurements_array=[]
-
+    
   while cycle_age < end_age:
 
     rawMeasurement = None

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="rcpchgrowth",
-    version="4.3.7",
+    version="4.3.8",
     description="SDS and Centile calculations for UK Growth Data",
     long_description=long_description,
     url="https://github.com/rcpch/digital-growth-charts/blob/master/README.md",


### PR DESCRIPTION
### Overview

The fictional child endpoint has for some time not produced values against corrected age, but only chronological. This has meant that producing fictional results for premature babies has given impossibly large numbers.

### Code changes

Refactors the fictional child function to take gestation into account if provided