### PR TITLE
typo fix in binder requirements.txt

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,1 +1,1 @@
-e .[notebook]
+.[notebook]


### PR DESCRIPTION
### Overview

[BUG FIX]

typo in the binder requirements.txt preventing binder build of notebook.
