### PR TITLE
change binder/requirements.txt to pull from pypi

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,1 +1,1 @@
--e "..[notebook]"
+rcpchgrowth["notebook"]

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The `notebook` extra currently pulls in: `pandas`, `matplotlib`, `jupyterlab`, `
 
 <table>
 <tr>
-  <td width="6" style="background:#2311a7f2;"></td>
+  <td width="6" style="background:#11A7F2;"></td>
   <td>
     <strong>Data handling & privacy</strong><br>
     <strong>Never commit identifiable patient data.</strong><br>


### PR DESCRIPTION
### Overview

The reason the binder fails to build is that the docker it creates cannot access the rcpchgrowth python package from the .binder folder.

This small change updates the .binder folder to pull the package from pypi instead.