### PR TITLE
extras must not have quotes in requirements.txt

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,1 +1,1 @@
-rcpchgrowth["notebook"]
+rcpchgrowth[notebook]


### PR DESCRIPTION
### Overview

removing quotes form extras in .binder/requirements.txt to allow package to pull from pypi
