### PR TITLE
Add error handling for mid-parental-height functions

### DIFF
--- a/notebooks/Quickstart.ipynb
+++ b/notebooks/Quickstart.ipynb
@@ -30,7 +30,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "rcpchgrowth 4.4.0 | Python 3.12.11\n"
+      "rcpchgrowth 4.4.0 | Python 3.12.12\n"
      ]
     }
    ],
@@ -612,7 +612,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/rcpchgrowth/constants/validation_constants.py
+++ b/rcpchgrowth/constants/validation_constants.py
@@ -41,6 +41,8 @@ MAXIMUM_GESTATION_WEEKS = 44
 MAXIMUM_GESTATION_WEEKS_ERROR = f"It is very unlikely that a gestational age of more than {MAXIMUM_GESTATION_WEEKS} weeks is correct"
 
 # PARENTAL HEIGHT CONSTANTS
+# Deprecated: retained for backward compatibility only.
+# Mid-parental-height validation now uses SDS error cut-offs.
 MINIMUM_PARENTAL_HEIGHT_CM = 50
 # the shortest man in the world was 54.6 cm Chandra Bahadur Dangi
 # the shortest woman in the world is Jyoti Kishanji Amge at 62.8 cm

--- a/rcpchgrowth/constants/validation_constants.py
+++ b/rcpchgrowth/constants/validation_constants.py
@@ -47,6 +47,12 @@ MINIMUM_PARENTAL_HEIGHT_CM = 50
 # lower limit to paternal and maternal height here therefore set arbitrarily at 50 cm
 # (this constant was added from the API server `schemas/request_validation_classes.py`)
 
+MAXIMUM_PARENTAL_HEIGHT_CM = 260
+# The tallest person for whom there is irrefutable evidence is
+# Robert Pershing Wadlow who was 2.72m (272 cm) tall at his death in 1940
+# https://en.wikipedia.org/wiki/Robert_Wadlow
+# Setting maximum at 260 cm to allow for measurement errors while still catching impossible values
+
 # These constants are used to determine the range of SDS values that are considered - see discussion in issue #32 in the rcpchgrowth-python repository
 # All previous hard-coded values have been replaced with these constants
 MINIMUM_HEIGHT_WEIGHT_OFC_ADVISORY_SDS = -4

--- a/rcpchgrowth/mid_parental_height.py
+++ b/rcpchgrowth/mid_parental_height.py
@@ -1,4 +1,4 @@
-from .constants import HEIGHT, MALE, FEMALE, UK_WHO, WHO
+from .constants import HEIGHT, MALE, FEMALE, UK_WHO, WHO, MINIMUM_PARENTAL_HEIGHT_CM, MAXIMUM_PARENTAL_HEIGHT_CM, REFERENCES, SEXES
 from .global_functions import sds_for_measurement
 """
 Functions to calculate mid-parental height
@@ -11,7 +11,37 @@ The strengths and limitations of parental heights as a predictor of attained hei
 def mid_parental_height(maternal_height, paternal_height, sex):
     """
     Calculate mid-parental height
+    
+    maternal_height: Maternal height in cm (float)
+    paternal_height: Paternal height in cm (float)
+    sex: Sex of the child ('male' or 'female')
+    return: Mid-parental height in cm (float)
+    raises ValueError: If any input is invalid
     """
+    # Validate sex
+    if sex not in SEXES:
+        raise ValueError(f"Sex must be '{MALE}' or '{FEMALE}', got '{sex}'")
+    
+    # Validate maternal_height
+    if maternal_height is None:
+        raise ValueError("Maternal height cannot be None. Please provide a height in cm.")
+    if not isinstance(maternal_height, (int, float)):
+        raise ValueError(f"Maternal height must be a number, got {type(maternal_height).__name__}")
+    if maternal_height < MINIMUM_PARENTAL_HEIGHT_CM:
+        raise ValueError(f"Maternal height of {maternal_height} cm is below the minimum of {MINIMUM_PARENTAL_HEIGHT_CM} cm and is considered to be an error.")
+    if maternal_height > MAXIMUM_PARENTAL_HEIGHT_CM:
+        raise ValueError(f"Maternal height of {maternal_height} cm is above the maximum of {MAXIMUM_PARENTAL_HEIGHT_CM} cm and is considered to be an error.")
+    
+    # Validate paternal_height
+    if paternal_height is None:
+        raise ValueError("Paternal height cannot be None. Please provide a height in cm.")
+    if not isinstance(paternal_height, (int, float)):
+        raise ValueError(f"Paternal height must be a number, got {type(paternal_height).__name__}")
+    if paternal_height < MINIMUM_PARENTAL_HEIGHT_CM:
+        raise ValueError(f"Paternal height of {paternal_height} cm is below the minimum of {MINIMUM_PARENTAL_HEIGHT_CM} cm and is considered to be an error.")
+    if paternal_height > MAXIMUM_PARENTAL_HEIGHT_CM:
+        raise ValueError(f"Paternal height of {paternal_height} cm is above the maximum of {MAXIMUM_PARENTAL_HEIGHT_CM} cm and is considered to be an error.")
+    
     if sex == MALE:
         return (maternal_height + paternal_height + 13) / 2
     else:
@@ -20,7 +50,36 @@ def mid_parental_height(maternal_height, paternal_height, sex):
 def mid_parental_height_z(maternal_height, paternal_height, reference=UK_WHO):
     """
     Calculate mid-parental height standard deviation
+    
+    :param maternal_height: Maternal height in cm (float)
+    :param paternal_height: Paternal height in cm (float)
+    :param reference: Reference dataset to use (default: 'uk-who')
+    :return: Mid-parental height z-score (float)
+    :raises ValueError: If any input is invalid
     """
+    # Validate reference
+    if reference not in REFERENCES:
+        raise ValueError(f"Reference must be one of {REFERENCES}, got '{reference}'")
+    
+    # Validate maternal_height
+    if maternal_height is None:
+        raise ValueError("Maternal height cannot be None. Please provide a height in cm.")
+    if not isinstance(maternal_height, (int, float)):
+        raise ValueError(f"Maternal height must be a number, got {type(maternal_height).__name__}")
+    if maternal_height < MINIMUM_PARENTAL_HEIGHT_CM:
+        raise ValueError(f"Maternal height of {maternal_height} cm is below the minimum of {MINIMUM_PARENTAL_HEIGHT_CM} cm and is considered to be an error.")
+    if maternal_height > MAXIMUM_PARENTAL_HEIGHT_CM:
+        raise ValueError(f"Maternal height of {maternal_height} cm is above the maximum of {MAXIMUM_PARENTAL_HEIGHT_CM} cm and is considered to be an error.")
+    
+    # Validate paternal_height
+    if paternal_height is None:
+        raise ValueError("Paternal height cannot be None. Please provide a height in cm.")
+    if not isinstance(paternal_height, (int, float)):
+        raise ValueError(f"Paternal height must be a number, got {type(paternal_height).__name__}")
+    if paternal_height < MINIMUM_PARENTAL_HEIGHT_CM:
+        raise ValueError(f"Paternal height of {paternal_height} cm is below the minimum of {MINIMUM_PARENTAL_HEIGHT_CM} cm and is considered to be an error.")
+    if paternal_height > MAXIMUM_PARENTAL_HEIGHT_CM:
+        raise ValueError(f"Paternal height of {paternal_height} cm is above the maximum of {MAXIMUM_PARENTAL_HEIGHT_CM} cm and is considered to be an error.")
     
     # convert parental heights to z-scores
     adult_age = 20.0

--- a/rcpchgrowth/mid_parental_height.py
+++ b/rcpchgrowth/mid_parental_height.py
@@ -1,4 +1,16 @@
-from .constants import HEIGHT, MALE, FEMALE, UK_WHO, WHO, MINIMUM_PARENTAL_HEIGHT_CM, MAXIMUM_PARENTAL_HEIGHT_CM, REFERENCES, SEXES
+import math
+
+from .constants import (
+    HEIGHT,
+    MALE,
+    FEMALE,
+    UK_WHO,
+    WHO,
+    REFERENCES,
+    SEXES,
+    MINIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS,
+    MAXIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS,
+)
 from .global_functions import sds_for_measurement
 """
 Functions to calculate mid-parental height
@@ -7,6 +19,62 @@ cf
 Tanner JM, Whitehouse RH, Takaishi M. Standards from birth to maturity for height, weight, height velocity, and weight velocity: British children, 1965. I. Arch Dis Child. 1966;41(219):454-471.
 The strengths and limitations of parental heights as a predictor of attained height, Charlotte M Wright, Tim D Cheetham, Arch Dis Child 1999;81:257–260
 """
+
+def _adult_age_for_reference(reference):
+    if reference == WHO:
+        return 19.0
+    return 20.0
+
+
+def _validate_parental_height_input(parent_height, parent_label):
+    if parent_height is None:
+        raise ValueError(f"{parent_label} height cannot be None. Please provide a height in cm.")
+    if isinstance(parent_height, bool) or not isinstance(parent_height, (int, float)):
+        raise ValueError(f"{parent_label} height must be a number, got {type(parent_height).__name__}")
+    if not math.isfinite(parent_height):
+        raise ValueError(f"{parent_label} height must be a finite number, got {parent_height}")
+
+
+def _validated_parental_height_z_scores(maternal_height, paternal_height, reference):
+    _validate_parental_height_input(maternal_height, "Maternal")
+    _validate_parental_height_input(paternal_height, "Paternal")
+
+    adult_age = _adult_age_for_reference(reference)
+
+    maternal_height_z = sds_for_measurement(
+        reference=reference,
+        age=adult_age,
+        measurement_method=HEIGHT,
+        observation_value=maternal_height,
+        sex=FEMALE,
+    )
+    paternal_height_z = sds_for_measurement(
+        reference=reference,
+        age=adult_age,
+        measurement_method=HEIGHT,
+        observation_value=paternal_height,
+        sex=MALE,
+    )
+
+    if maternal_height_z < MINIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS:
+        raise ValueError(
+            f"The maternal height of {maternal_height} cm is below {MINIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS} SD and considered to be an error."
+        )
+    if maternal_height_z > MAXIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS:
+        raise ValueError(
+            f"The maternal height of {maternal_height} cm is above {MAXIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS:+g} SD and considered to be an error."
+        )
+    if paternal_height_z < MINIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS:
+        raise ValueError(
+            f"The paternal height of {paternal_height} cm is below {MINIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS} SD and considered to be an error."
+        )
+    if paternal_height_z > MAXIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS:
+        raise ValueError(
+            f"The paternal height of {paternal_height} cm is above {MAXIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS:+g} SD and considered to be an error."
+        )
+
+    return maternal_height_z, paternal_height_z
+
 
 def mid_parental_height(maternal_height, paternal_height, sex):
     """
@@ -22,25 +90,11 @@ def mid_parental_height(maternal_height, paternal_height, sex):
     if sex not in SEXES:
         raise ValueError(f"Sex must be '{MALE}' or '{FEMALE}', got '{sex}'")
     
-    # Validate maternal_height
-    if maternal_height is None:
-        raise ValueError("Maternal height cannot be None. Please provide a height in cm.")
-    if not isinstance(maternal_height, (int, float)):
-        raise ValueError(f"Maternal height must be a number, got {type(maternal_height).__name__}")
-    if maternal_height < MINIMUM_PARENTAL_HEIGHT_CM:
-        raise ValueError(f"Maternal height of {maternal_height} cm is below the minimum of {MINIMUM_PARENTAL_HEIGHT_CM} cm and is considered to be an error.")
-    if maternal_height > MAXIMUM_PARENTAL_HEIGHT_CM:
-        raise ValueError(f"Maternal height of {maternal_height} cm is above the maximum of {MAXIMUM_PARENTAL_HEIGHT_CM} cm and is considered to be an error.")
-    
-    # Validate paternal_height
-    if paternal_height is None:
-        raise ValueError("Paternal height cannot be None. Please provide a height in cm.")
-    if not isinstance(paternal_height, (int, float)):
-        raise ValueError(f"Paternal height must be a number, got {type(paternal_height).__name__}")
-    if paternal_height < MINIMUM_PARENTAL_HEIGHT_CM:
-        raise ValueError(f"Paternal height of {paternal_height} cm is below the minimum of {MINIMUM_PARENTAL_HEIGHT_CM} cm and is considered to be an error.")
-    if paternal_height > MAXIMUM_PARENTAL_HEIGHT_CM:
-        raise ValueError(f"Paternal height of {paternal_height} cm is above the maximum of {MAXIMUM_PARENTAL_HEIGHT_CM} cm and is considered to be an error.")
+    _validated_parental_height_z_scores(
+        maternal_height=maternal_height,
+        paternal_height=paternal_height,
+        reference=UK_WHO,
+    )
     
     if sex == MALE:
         return (maternal_height + paternal_height + 13) / 2
@@ -61,33 +115,12 @@ def mid_parental_height_z(maternal_height, paternal_height, reference=UK_WHO):
     if reference not in REFERENCES:
         raise ValueError(f"Reference must be one of {REFERENCES}, got '{reference}'")
     
-    # Validate maternal_height
-    if maternal_height is None:
-        raise ValueError("Maternal height cannot be None. Please provide a height in cm.")
-    if not isinstance(maternal_height, (int, float)):
-        raise ValueError(f"Maternal height must be a number, got {type(maternal_height).__name__}")
-    if maternal_height < MINIMUM_PARENTAL_HEIGHT_CM:
-        raise ValueError(f"Maternal height of {maternal_height} cm is below the minimum of {MINIMUM_PARENTAL_HEIGHT_CM} cm and is considered to be an error.")
-    if maternal_height > MAXIMUM_PARENTAL_HEIGHT_CM:
-        raise ValueError(f"Maternal height of {maternal_height} cm is above the maximum of {MAXIMUM_PARENTAL_HEIGHT_CM} cm and is considered to be an error.")
-    
-    # Validate paternal_height
-    if paternal_height is None:
-        raise ValueError("Paternal height cannot be None. Please provide a height in cm.")
-    if not isinstance(paternal_height, (int, float)):
-        raise ValueError(f"Paternal height must be a number, got {type(paternal_height).__name__}")
-    if paternal_height < MINIMUM_PARENTAL_HEIGHT_CM:
-        raise ValueError(f"Paternal height of {paternal_height} cm is below the minimum of {MINIMUM_PARENTAL_HEIGHT_CM} cm and is considered to be an error.")
-    if paternal_height > MAXIMUM_PARENTAL_HEIGHT_CM:
-        raise ValueError(f"Paternal height of {paternal_height} cm is above the maximum of {MAXIMUM_PARENTAL_HEIGHT_CM} cm and is considered to be an error.")
-    
     # convert parental heights to z-scores
-    adult_age = 20.0
-    if reference == WHO:
-        adult_age = 19.0
-    
-    maternal_height_z = sds_for_measurement(reference=reference, age=adult_age, measurement_method=HEIGHT, observation_value=maternal_height, sex=FEMALE)
-    paternal_height_z = sds_for_measurement(reference=reference, age=adult_age, measurement_method=HEIGHT, observation_value=paternal_height, sex=MALE)
+    maternal_height_z, paternal_height_z = _validated_parental_height_z_scores(
+        maternal_height=maternal_height,
+        paternal_height=paternal_height,
+        reference=reference,
+    )
 
     # take the means of the z-scores and apply the regression coefficient of 0.5 - simplifed: (MatHtz +PatHtz)/4
     mid_parental_height_z_score = (maternal_height_z + paternal_height_z) / 4.0

--- a/rcpchgrowth/tests/test_mid_parental_height.py
+++ b/rcpchgrowth/tests/test_mid_parental_height.py
@@ -1,11 +1,30 @@
 import pytest
 
-from rcpchgrowth.constants import MALE, FEMALE, UK_WHO, CDC, MINIMUM_PARENTAL_HEIGHT_CM, MAXIMUM_PARENTAL_HEIGHT_CM
+from rcpchgrowth.constants import (
+    MALE,
+    FEMALE,
+    UK_WHO,
+    CDC,
+    HEIGHT,
+    MINIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS,
+    MAXIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS,
+)
+from rcpchgrowth.global_functions import measurement_from_sds
 from rcpchgrowth.mid_parental_height import mid_parental_height, mid_parental_height_z, expected_height_z_from_mid_parental_height_z
 
 maternal_height = 151
 paternal_height = 167
 ACCURACY = 1e-3
+
+
+def _parental_height_for_sds(requested_sds, sex):
+    return measurement_from_sds(
+        reference=UK_WHO,
+        age=20.0,
+        measurement_method=HEIGHT,
+        sex=sex,
+        requested_sds=requested_sds,
+    )
 
 
 def test_midparental_height():
@@ -47,37 +66,39 @@ def test_midparental_height_validation_non_numeric():
 
 
 def test_midparental_height_validation_below_minimum():
-    """Test that heights below minimum raise appropriate errors"""
-    too_short = MINIMUM_PARENTAL_HEIGHT_CM - 1
+    """Test that heights below -8 SDS raise appropriate errors."""
+    maternal_too_short = _parental_height_for_sds(MINIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS - 0.5, FEMALE)
+    paternal_too_short = _parental_height_for_sds(MINIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS - 0.5, MALE)
     
-    with pytest.raises(ValueError, match=f"Maternal height of {too_short} cm is below the minimum"):
-        mid_parental_height(maternal_height=too_short, paternal_height=paternal_height, sex=MALE)
+    with pytest.raises(ValueError, match="The maternal height of .* is below -8 SD"):
+        mid_parental_height(maternal_height=maternal_too_short, paternal_height=paternal_height, sex=MALE)
     
-    with pytest.raises(ValueError, match=f"Paternal height of {too_short} cm is below the minimum"):
-        mid_parental_height(maternal_height=maternal_height, paternal_height=too_short, sex=MALE)
+    with pytest.raises(ValueError, match="The paternal height of .* is below -8 SD"):
+        mid_parental_height(maternal_height=maternal_height, paternal_height=paternal_too_short, sex=MALE)
     
-    with pytest.raises(ValueError, match=f"Maternal height of {too_short} cm is below the minimum"):
-        mid_parental_height_z(maternal_height=too_short, paternal_height=paternal_height, reference=UK_WHO)
+    with pytest.raises(ValueError, match="The maternal height of .* is below -8 SD"):
+        mid_parental_height_z(maternal_height=maternal_too_short, paternal_height=paternal_height, reference=UK_WHO)
     
-    with pytest.raises(ValueError, match=f"Paternal height of {too_short} cm is below the minimum"):
-        mid_parental_height_z(maternal_height=maternal_height, paternal_height=too_short, reference=UK_WHO)
+    with pytest.raises(ValueError, match="The paternal height of .* is below -8 SD"):
+        mid_parental_height_z(maternal_height=maternal_height, paternal_height=paternal_too_short, reference=UK_WHO)
 
 
 def test_midparental_height_validation_above_maximum():
-    """Test that heights above maximum raise appropriate errors"""
-    too_tall = MAXIMUM_PARENTAL_HEIGHT_CM + 1
+    """Test that heights above +8 SDS raise appropriate errors."""
+    maternal_too_tall = _parental_height_for_sds(MAXIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS + 0.5, FEMALE)
+    paternal_too_tall = _parental_height_for_sds(MAXIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS + 0.5, MALE)
     
-    with pytest.raises(ValueError, match=f"Maternal height of {too_tall} cm is above the maximum"):
-        mid_parental_height(maternal_height=too_tall, paternal_height=paternal_height, sex=MALE)
+    with pytest.raises(ValueError, match=r"The maternal height of .* is above \+8 SD"):
+        mid_parental_height(maternal_height=maternal_too_tall, paternal_height=paternal_height, sex=MALE)
     
-    with pytest.raises(ValueError, match=f"Paternal height of {too_tall} cm is above the maximum"):
-        mid_parental_height(maternal_height=maternal_height, paternal_height=too_tall, sex=MALE)
+    with pytest.raises(ValueError, match=r"The paternal height of .* is above \+8 SD"):
+        mid_parental_height(maternal_height=maternal_height, paternal_height=paternal_too_tall, sex=MALE)
     
-    with pytest.raises(ValueError, match=f"Maternal height of {too_tall} cm is above the maximum"):
-        mid_parental_height_z(maternal_height=too_tall, paternal_height=paternal_height, reference=UK_WHO)
+    with pytest.raises(ValueError, match=r"The maternal height of .* is above \+8 SD"):
+        mid_parental_height_z(maternal_height=maternal_too_tall, paternal_height=paternal_height, reference=UK_WHO)
     
-    with pytest.raises(ValueError, match=f"Paternal height of {too_tall} cm is above the maximum"):
-        mid_parental_height_z(maternal_height=maternal_height, paternal_height=too_tall, reference=UK_WHO)
+    with pytest.raises(ValueError, match=r"The paternal height of .* is above \+8 SD"):
+        mid_parental_height_z(maternal_height=maternal_height, paternal_height=paternal_too_tall, reference=UK_WHO)
 
 
 def test_midparental_height_validation_invalid_sex():
@@ -102,16 +123,32 @@ def test_midparental_height_z_validation_invalid_reference():
 
 
 def test_midparental_height_validation_boundary_values():
-    """Test that boundary values (minimum and maximum) are accepted"""
-    # Test minimum boundary
-    assert mid_parental_height(maternal_height=MINIMUM_PARENTAL_HEIGHT_CM, paternal_height=MINIMUM_PARENTAL_HEIGHT_CM, sex=MALE) == (MINIMUM_PARENTAL_HEIGHT_CM + MINIMUM_PARENTAL_HEIGHT_CM + 13) / 2
-    
-    # Test maximum boundary
-    assert mid_parental_height(maternal_height=MAXIMUM_PARENTAL_HEIGHT_CM, paternal_height=MAXIMUM_PARENTAL_HEIGHT_CM, sex=FEMALE) == (MAXIMUM_PARENTAL_HEIGHT_CM + MAXIMUM_PARENTAL_HEIGHT_CM - 13) / 2
-    
-    # Test that z-score calculation works with boundary values
-    result = mid_parental_height_z(maternal_height=MINIMUM_PARENTAL_HEIGHT_CM, paternal_height=MINIMUM_PARENTAL_HEIGHT_CM, reference=UK_WHO)
-    assert isinstance(result, float)
-    
-    result = mid_parental_height_z(maternal_height=MAXIMUM_PARENTAL_HEIGHT_CM, paternal_height=MAXIMUM_PARENTAL_HEIGHT_CM, reference=UK_WHO)
-    assert isinstance(result, float)
+    """Test that boundary SDS values (-8 and +8) are accepted."""
+    maternal_at_min = _parental_height_for_sds(MINIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS, FEMALE)
+    paternal_at_min = _parental_height_for_sds(MINIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS, MALE)
+    maternal_at_max = _parental_height_for_sds(MAXIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS, FEMALE)
+    paternal_at_max = _parental_height_for_sds(MAXIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS, MALE)
+
+    assert mid_parental_height(
+        maternal_height=maternal_at_min,
+        paternal_height=paternal_at_min,
+        sex=MALE,
+    ) == pytest.approx((maternal_at_min + paternal_at_min + 13) / 2, ACCURACY)
+
+    assert mid_parental_height(
+        maternal_height=maternal_at_max,
+        paternal_height=paternal_at_max,
+        sex=FEMALE,
+    ) == pytest.approx((maternal_at_max + paternal_at_max - 13) / 2, ACCURACY)
+
+    assert mid_parental_height_z(
+        maternal_height=maternal_at_min,
+        paternal_height=paternal_at_min,
+        reference=UK_WHO,
+    ) == pytest.approx(-4.0, ACCURACY)
+
+    assert mid_parental_height_z(
+        maternal_height=maternal_at_max,
+        paternal_height=paternal_at_max,
+        reference=UK_WHO,
+    ) == pytest.approx(4.0, ACCURACY)

--- a/rcpchgrowth/tests/test_mid_parental_height.py
+++ b/rcpchgrowth/tests/test_mid_parental_height.py
@@ -1,6 +1,6 @@
 import pytest
 
-from rcpchgrowth.constants import MALE, FEMALE, UK_WHO, CDC
+from rcpchgrowth.constants import MALE, FEMALE, UK_WHO, CDC, MINIMUM_PARENTAL_HEIGHT_CM, MAXIMUM_PARENTAL_HEIGHT_CM
 from rcpchgrowth.mid_parental_height import mid_parental_height, mid_parental_height_z, expected_height_z_from_mid_parental_height_z
 
 maternal_height = 151
@@ -14,3 +14,104 @@ def test_midparental_height():
     assert mid_parental_height_z(maternal_height=maternal_height, paternal_height=paternal_height, reference=UK_WHO) == pytest.approx(-0.8943229, ACCURACY)
     assert mid_parental_height_z(maternal_height=maternal_height, paternal_height=paternal_height, reference=CDC) == pytest.approx(-0.8177165233046019, ACCURACY)
     assert expected_height_z_from_mid_parental_height_z(mid_parental_height_z=-0.8943229) == pytest.approx(-0.44716145, ACCURACY)
+
+
+def test_midparental_height_validation_none_values():
+    """Test that None values raise appropriate errors"""
+    with pytest.raises(ValueError, match="Maternal height cannot be None"):
+        mid_parental_height(maternal_height=None, paternal_height=paternal_height, sex=MALE)
+    
+    with pytest.raises(ValueError, match="Paternal height cannot be None"):
+        mid_parental_height(maternal_height=maternal_height, paternal_height=None, sex=MALE)
+    
+    with pytest.raises(ValueError, match="Maternal height cannot be None"):
+        mid_parental_height_z(maternal_height=None, paternal_height=paternal_height, reference=UK_WHO)
+    
+    with pytest.raises(ValueError, match="Paternal height cannot be None"):
+        mid_parental_height_z(maternal_height=maternal_height, paternal_height=None, reference=UK_WHO)
+
+
+def test_midparental_height_validation_non_numeric():
+    """Test that non-numeric values raise appropriate errors"""
+    with pytest.raises(ValueError, match="Maternal height must be a number"):
+        mid_parental_height(maternal_height="151", paternal_height=paternal_height, sex=MALE)
+    
+    with pytest.raises(ValueError, match="Paternal height must be a number"):
+        mid_parental_height(maternal_height=maternal_height, paternal_height="167", sex=MALE)
+    
+    with pytest.raises(ValueError, match="Maternal height must be a number"):
+        mid_parental_height_z(maternal_height=[151], paternal_height=paternal_height, reference=UK_WHO)
+    
+    with pytest.raises(ValueError, match="Paternal height must be a number"):
+        mid_parental_height_z(maternal_height=maternal_height, paternal_height={"height": 167}, reference=UK_WHO)
+
+
+def test_midparental_height_validation_below_minimum():
+    """Test that heights below minimum raise appropriate errors"""
+    too_short = MINIMUM_PARENTAL_HEIGHT_CM - 1
+    
+    with pytest.raises(ValueError, match=f"Maternal height of {too_short} cm is below the minimum"):
+        mid_parental_height(maternal_height=too_short, paternal_height=paternal_height, sex=MALE)
+    
+    with pytest.raises(ValueError, match=f"Paternal height of {too_short} cm is below the minimum"):
+        mid_parental_height(maternal_height=maternal_height, paternal_height=too_short, sex=MALE)
+    
+    with pytest.raises(ValueError, match=f"Maternal height of {too_short} cm is below the minimum"):
+        mid_parental_height_z(maternal_height=too_short, paternal_height=paternal_height, reference=UK_WHO)
+    
+    with pytest.raises(ValueError, match=f"Paternal height of {too_short} cm is below the minimum"):
+        mid_parental_height_z(maternal_height=maternal_height, paternal_height=too_short, reference=UK_WHO)
+
+
+def test_midparental_height_validation_above_maximum():
+    """Test that heights above maximum raise appropriate errors"""
+    too_tall = MAXIMUM_PARENTAL_HEIGHT_CM + 1
+    
+    with pytest.raises(ValueError, match=f"Maternal height of {too_tall} cm is above the maximum"):
+        mid_parental_height(maternal_height=too_tall, paternal_height=paternal_height, sex=MALE)
+    
+    with pytest.raises(ValueError, match=f"Paternal height of {too_tall} cm is above the maximum"):
+        mid_parental_height(maternal_height=maternal_height, paternal_height=too_tall, sex=MALE)
+    
+    with pytest.raises(ValueError, match=f"Maternal height of {too_tall} cm is above the maximum"):
+        mid_parental_height_z(maternal_height=too_tall, paternal_height=paternal_height, reference=UK_WHO)
+    
+    with pytest.raises(ValueError, match=f"Paternal height of {too_tall} cm is above the maximum"):
+        mid_parental_height_z(maternal_height=maternal_height, paternal_height=too_tall, reference=UK_WHO)
+
+
+def test_midparental_height_validation_invalid_sex():
+    """Test that invalid sex values raise appropriate errors"""
+    with pytest.raises(ValueError, match="Sex must be 'male' or 'female'"):
+        mid_parental_height(maternal_height=maternal_height, paternal_height=paternal_height, sex="invalid")
+    
+    with pytest.raises(ValueError, match="Sex must be 'male' or 'female'"):
+        mid_parental_height(maternal_height=maternal_height, paternal_height=paternal_height, sex="MALE")  # wrong case
+    
+    with pytest.raises(ValueError, match="Sex must be 'male' or 'female'"):
+        mid_parental_height(maternal_height=maternal_height, paternal_height=paternal_height, sex=None)
+
+
+def test_midparental_height_z_validation_invalid_reference():
+    """Test that invalid reference values raise appropriate errors"""
+    with pytest.raises(ValueError, match="Reference must be one of"):
+        mid_parental_height_z(maternal_height=maternal_height, paternal_height=paternal_height, reference="invalid")
+    
+    with pytest.raises(ValueError, match="Reference must be one of"):
+        mid_parental_height_z(maternal_height=maternal_height, paternal_height=paternal_height, reference=None)
+
+
+def test_midparental_height_validation_boundary_values():
+    """Test that boundary values (minimum and maximum) are accepted"""
+    # Test minimum boundary
+    assert mid_parental_height(maternal_height=MINIMUM_PARENTAL_HEIGHT_CM, paternal_height=MINIMUM_PARENTAL_HEIGHT_CM, sex=MALE) == (MINIMUM_PARENTAL_HEIGHT_CM + MINIMUM_PARENTAL_HEIGHT_CM + 13) / 2
+    
+    # Test maximum boundary
+    assert mid_parental_height(maternal_height=MAXIMUM_PARENTAL_HEIGHT_CM, paternal_height=MAXIMUM_PARENTAL_HEIGHT_CM, sex=FEMALE) == (MAXIMUM_PARENTAL_HEIGHT_CM + MAXIMUM_PARENTAL_HEIGHT_CM - 13) / 2
+    
+    # Test that z-score calculation works with boundary values
+    result = mid_parental_height_z(maternal_height=MINIMUM_PARENTAL_HEIGHT_CM, paternal_height=MINIMUM_PARENTAL_HEIGHT_CM, reference=UK_WHO)
+    assert isinstance(result, float)
+    
+    result = mid_parental_height_z(maternal_height=MAXIMUM_PARENTAL_HEIGHT_CM, paternal_height=MAXIMUM_PARENTAL_HEIGHT_CM, reference=UK_WHO)
+    assert isinstance(result, float)


### PR DESCRIPTION
Fixes issue: mid-parental-height accepts impossible values #53 

- Add MAXIMUM_PARENTAL_HEIGHT_CM constant (260 cm) to validation_constants.py
- Add comprehensive input validation to mid_parental_height() function
- Add input validation to mid_parental_height_z() function
- Add 7 new test functions covering all validation scenarios
