### PR TITLE
Fix/import fail

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rcpchgrowth"
-version = "4.4.0"
+version = "4.4.1"
 description = "SDS and Centile calculations for UK Growth Data"
 keywords = ["growth charts", "anthropometry", "SDS", "centile", "UK-WHO", "UK90", "Trisomy 21", "Turner", "CDC"]
 license = "AGPL-3.0-or-later"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ notebook = [
 include-package-data = true
 
 [tool.setuptools.packages.find]
-include = ["rcpchgrowth"]
+include = ["rcpchgrowth*"]
 exclude = ["notebooks"]
 
 [project.readme]


### PR DESCRIPTION
### Overview

Raised by 0tusSc0ps #81

When this package was moved from using `setup.py` to `pyproject.toml` (4.4.0) it was silently omitting sub-packages from the wheel, meaning `constants` and `data-tables` were both missing.

By importing ["rcpchgrowth*"] in `pyproject.toml` now all the sub-packages should be imported