### PR TITLE
83 update python versions across dockerfile, CI testing matrix, and other appearances

### DIFF
--- a/.binder/runtime.txt
+++ b/.binder/runtime.txt
@@ -1,1 +1,1 @@
-python-3.10
+python-3.12

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Cache pip
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/run-pytest-on-push-and-all-prs.yml
+++ b/.github/workflows/run-pytest-on-push-and-all-prs.yml
@@ -28,7 +28,7 @@ jobs:
     # Runs tests on multiple python versions across the range we support
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 # Environment hygiene
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       # Mount the entire project directory for live development
       - .:/app
       # Prevent overwriting installed packages and cache directories
-      - /usr/local/lib/python3.12/site-packages
+      - /usr/local/lib/python3.13/site-packages
       - /app/.pytest_cache
     working_dir: /app
     environment:

--- a/notebooks/Quickstart.ipynb
+++ b/notebooks/Quickstart.ipynb
@@ -143,7 +143,7 @@
     "}\n",
     "```\n",
     "\n",
-    "### `measurement_calculated_values\n",
+    "### `measurement_calculated_values`\n",
     "\n",
     "These are the sds and centile calculations. Note that corrected and chronological results are always provided, even if the gestation is 40+0 (when they will be the same).\n",
     "\n",
@@ -612,7 +612,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 maintainers = [
   { name = "RCPCH Incubator", email = "incubator@rcpch.ac.uk" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
   "python-dateutil",
   "scipy",
@@ -23,10 +23,10 @@ dependencies = [
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering :: Medical Science Apps.",
 ]
 


### PR DESCRIPTION
### Overview

* **BASED ON PR #80 - I would recommend merging that first**
* Updates the Python versions, which had become somewhat out-of-sync, across various parts of the repo
* Doesn't remove `setup.py`, although I'm fairly sure it is not in use, it had drifted from `pyproject.toml` - but see https://github.com/rcpch/rcpchgrowth-python/issues/23 and potentially remove.
* Closes #83 when merged
