### PR TITLE
Pin GitHub Actions to commit SHAs; add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Dependabot configuration.
+#
+# - Keeps GitHub Actions up to date.
+# - Actions are pinned to commit SHAs in workflows; Dependabot still
+#   recognises and updates SHA-pinned uses, preserving the trailing
+#   "# vX.Y.Z" version comment when it opens an update PR.
+# - The cooldown.default-days value gives 7 days between an upstream
+#   release and Dependabot raising a PR for it. This reduces exposure to
+#   compromised releases that get yanked or revoked shortly after publication
+#   (a common supply-chain attack pattern), while still keeping us current.
+#
+# Docs: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,6 +1,18 @@
 # This workflow will upload a Python Package using Twine when a release is created
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
+# Third-party GitHub Actions are pinned to a full 40-character commit SHA
+# (with a `# vX.Y.Z` trailing comment for human readability). This protects
+# against tag re-pointing supply-chain attacks: a tag like `v4` is mutable
+# and can be silently rewritten to malicious code, but a commit SHA is not.
+# Dependabot (see .github/dependabot.yml) recognises this pattern and keeps
+# both the SHA and the version comment in sync when raising update PRs.
+#
+# Convention reference:
+#   https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
+# Tooling that automates the pin/unpin cycle:
+#   https://github.com/mheap/pin-github-action
+
 name: Upload Python Package
 
 on:
@@ -12,15 +24,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml', 'requirements.txt') }}

--- a/.github/workflows/run-pytest-on-push-and-all-prs.yml
+++ b/.github/workflows/run-pytest-on-push-and-all-prs.yml
@@ -1,5 +1,17 @@
 name: Run Pytest on pushes to main branches or PRs to any branch
 
+# Third-party GitHub Actions are pinned to a full 40-character commit SHA
+# (with a `# vX.Y.Z` trailing comment for human readability). This protects
+# against tag re-pointing supply-chain attacks: a tag like `v4` is mutable
+# and can be silently rewritten to malicious code, but a commit SHA is not.
+# Dependabot (see .github/dependabot.yml) recognises this pattern and keeps
+# both the SHA and the version comment in sync when raising update PRs.
+#
+# Convention reference:
+#   https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
+# Tooling that automates the pin/unpin cycle:
+#   https://github.com/mheap/pin-github-action
+
 on:
   pull_request:
     branches:
@@ -19,15 +31,15 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'requirements.txt') }}


### PR DESCRIPTION
Per #85: pin third-party GitHub Actions to immutable commit SHAs (with a trailing version-tag comment for human readability) to mitigate supply-chain attacks via tag re-pointing. Add a Dependabot config that maintains the github-actions ecosystem with a 7-day cooldown so we don't adopt brand-new releases until any yanks/revocations have surfaced.

Each workflow has a header comment explaining the SHA-pinning convention and linking to the GitHub security-hardening docs and the mheap/pin-github-action tool.

Versions chosen are the latest stable that are also more than 7 days old (verified against each repo's official Releases page on 2 Jun 2026):
- actions/checkout: v4 -> v6.0.2 (de0fac2, released 2026-01-09)
  - v6.0.3 was released today and skipped per the cooldown policy.
- actions/setup-python: v5 -> v6.2.0 (a309ff8, released 2026-01-22)
- actions/cache: v4 -> v5.0.5 (27d5ce7, released 2026-04-13)

Closes #85

Based on `live` so can be merged ahead of #80 and subsequent PRs without causing too much mayhem.